### PR TITLE
Fix problems transitioning from insecure_private_key to less_insecure_private_key (Vagrant >= 1.4.0)

### DIFF
--- a/lib/vagrant-rekey-ssh/actions/ssh_info.rb
+++ b/lib/vagrant-rekey-ssh/actions/ssh_info.rb
@@ -31,7 +31,7 @@ module VagrantPlugins
               if Vagrant::VERSION < "1.4.0"
                 @machine.config.ssh.private_key_path = ssh_key_path
               else
-                @machine.config.ssh.private_key_path = [ssh_key_path]
+                @machine.config.ssh.private_key_path = [ssh_key_path, @machine.env.default_private_key_path]
               end
             end
             


### PR DESCRIPTION
Without this, `vagrant reload` after installing the plugin just hangs
forever waiting for the VM to boot, with output similar to the
following:

```
==> default: Less insecure SSH key not found, generating key
==> default: Less insecure SSH key generated and stored at /Users/dlitz/.vagrant.d/less_insecure_private_key
==> default: Attempting graceful shutdown of VM...
    default: Guest communication could not be established! This is usually because
    default: SSH is not running, the authentication information was changed,
    default: or some other networking issue. Vagrant will force halt, if
    default: capable.
==> default: Stopping the VMware VM...
==> default: Verifying vmnet devices are healthy...
==> default: Preparing network adapters...
==> default: Starting the VMware VM...
==> default: Waiting for the VM to finish booting...
```

This doesn't fix Vagrant < 1.4.0
