### PR TITLE
Fix "passwd: unrecognized option '--delete'" under busybox

### DIFF
--- a/lib/vagrant-rekey-ssh/actions/secure_box.rb
+++ b/lib/vagrant-rekey-ssh/actions/secure_box.rb
@@ -47,7 +47,7 @@ module VagrantPlugins
             # -> this prevents the user from logging in using 'vagrant'
             # -> we only do this if the insecure key was found, because if it
             #    wasn't then perhaps it's a custom box and we shouldn't mess with it
-            @machine.communicate.execute("sudo passwd --delete $USER; sudo passwd --delete root", sudo: false)  
+            @machine.communicate.execute("sudo passwd -d $USER; sudo passwd -d root", sudo: false)
             
             
             


### PR DESCRIPTION
Use `passwd -d` instead.

This fixes VMs like boot2docker, where we end up getting this error:

```
passwd: unrecognized option '--delete'
BusyBox v1.21.1 (2013-12-27 19:35:36 UTC) multi-call binary.

Usage: passwd [OPTIONS] [USER]

Change USER's password (default: current user)

        -a ALG  Encryption method
        -d      Set password to ''
        -l      Lock (disable) account
        -u      Unlock (enable) account
```

Tested on Mac OS X using dvm (https://github.com/fnichol/dvm)
