### PR TITLE
Use sshkey library instead of ssh-keygen to get Windows support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,12 @@ Compatibility
 -------------
 
 I've only tested this on Vagrant 1.3.5 using the Virtualbox provider on Ubuntu
-and OSX. Let me know if it works on earlier versions of Vagrant, and I'll put
-that here.
+and OSX. In addition, it was tested on Windows 8.1 with Vagrant 1.6.3 and the
+VirtualBox provider. Let me know if it works on earlier versions of Vagrant,
+and I'll put that here.
 
 Known Issues
 ------------
-
-This isn't going to work on a Vagrant VM that is running a non-unix operating
-system.
 
 I haven't figured out a generic way to override a machine's configuration
 without hooking specific actions, which results in the following bugs that

--- a/lib/vagrant-rekey-ssh/helpers.rb
+++ b/lib/vagrant-rekey-ssh/helpers.rb
@@ -1,4 +1,6 @@
 
+require 'sshkey'
+
 module VagrantPlugins
   module RekeySSH
     module Helpers
@@ -8,10 +10,12 @@ module VagrantPlugins
 
           @machine.ui.info(I18n.t("vagrant_rekey_ssh.info.generating_key"))
                     
-          result = Vagrant::Util::Subprocess.execute("ssh-keygen", "-f", ssh_key_path, "-N", "")
-          
-          if result.exit_code != 0
-            raise Errors::ErrorCreatingSshKey, exit_code: result.exit_code
+          key = SSHKey.generate(:comment => "vagrant less insecure private key")
+          begin
+            File.write(ssh_key_path, key.private_key)
+            File.write(ssh_pubkey_path, key.ssh_public_key)
+          rescue => exc
+            raise Errors::ErrorCreatingSshKey, error_message: exc.message
           end
           
           @machine.ui.info(I18n.t("vagrant_rekey_ssh.info.key_generated", :path => ssh_key_path))

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -17,6 +17,6 @@ en:
 
     errors:
       creating_ssh_key: |-
-        Error occurred when creating the ssh key (ssh-keygen returned %{exit_code})
+        Error occurred when creating the ssh key (%{error_message})
       invalid_generated_ssh_key: |-
         Generated SSH key was not in an expected format! Perhaps it was corrupted?

--- a/vagrant-rekey-ssh.gemspec
+++ b/vagrant-rekey-ssh.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_runtime_dependency "sshkey"
 end


### PR DESCRIPTION
See https://github.com/bensie/sshkey.
