### PR TITLE
set correct permissions for the ssh key

### DIFF
--- a/lib/vagrant-rekey-ssh/helpers.rb
+++ b/lib/vagrant-rekey-ssh/helpers.rb
@@ -13,6 +13,8 @@ module VagrantPlugins
           key = SSHKey.generate(:comment => "vagrant less insecure private key")
           begin
             File.write(ssh_key_path, key.private_key)
+            # Fix ssh key permissions on Unix systems
+            File.chmod(600, ssh_key_path) if (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) == nil
             File.write(ssh_pubkey_path, key.ssh_public_key)
           rescue => exc
             raise Errors::ErrorCreatingSshKey, error_message: exc.message


### PR DESCRIPTION
SSH will reject private keys which are readable by other users. Vagrant internally fixes permissions on the key if you run `vagrant ssh`, but any other tools that attempt to connect using this key before that fix happens will fail. These permissions are not valid on Windows.
